### PR TITLE
Good logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ serial_bridge
 # Code running onboard
 ONBOARD = onboard
 
+# Includes accessible by anyone
+COMMON_INCLUDE = .
+
 LCM_TYPES_DIR = biped_lcm
 LCM_PACKAGE_NAME = biped_lcm
 LCM_TARGET_JAR = biped_lcm.jar
@@ -17,7 +20,7 @@ LCM_JAR = $(DRAKE_DISTRO)/build/install/share/java/lcm.jar
 #----------------------------------------------
 
 export CXX=g++
-export CXXFLAGS=-std=c++11 -Wall
+export CXXFLAGS=-std=c++11 -Wall -I$(realpath $(COMMON_INCLUDE))
 
 BUILD_DIR = build
 
@@ -39,7 +42,7 @@ LCM_JAR_DEPS = $(patsubst $(LCM_TYPES_DIR)/%.lcm, $(LCM_PACKAGE_NAME)/%.class, $
 #---------- Other misc vars
 # Used by onboard compilation
 # Add the LCM headers to the include path
-export CPPFLAGS=-I$(realpath $(LCM_B_DIR)) `pkg-config --cflags-only-I lcm`
+export CPPFLAGS=-I$(realpath $(LCM_B_DIR)) -I$(realpath $(COMMON_INCLUDE)) `pkg-config --cflags-only-I lcm`
 
 NODE_TARGETS = $(addprefix $(BUILD_DIR)/,$(addsuffix /$(NODE_TARGET_NAME), $(NODES)))
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 # List all independent nodes, separated with escaped newlines
 NODES = \
 serial_bridge \
-cmd_tester
+cmd_tester \
+log_listener
 
 # Code running onboard
 ONBOARD = onboard

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # List all independent nodes, separated with escaped newlines
 NODES = \
-serial_bridge 
+serial_bridge \
+cmd_tester
 
 # Code running onboard
 ONBOARD = onboard

--- a/biped_lcm/error_channel.lcm
+++ b/biped_lcm/error_channel.lcm
@@ -1,7 +1,0 @@
-package biped_lcm;
-
-struct error_channel
-{
-//  string name; it does not accept strings for a reason as a type
-  int8_t jointNumber;
-}

--- a/biped_lcm/log_msg.lcm
+++ b/biped_lcm/log_msg.lcm
@@ -1,0 +1,7 @@
+package biped_lcm;
+
+struct log_msg {
+	const int8_t	ERROR=0, WARN=1, INFO=2;
+	int8_t		log_level;
+	string		msg;
+}

--- a/cmd_tester/Makefile
+++ b/cmd_tester/Makefile
@@ -1,0 +1,9 @@
+# NEEDED VARS: BDIR_ABS, LCM_BDIR_ABS, TARGET
+
+LIBS= -lserial 
+
+#optional vars for include, src:
+#IDIR=  
+#SDIR=
+
+include ../Common.mk

--- a/cmd_tester/cmd_tester.cpp
+++ b/cmd_tester/cmd_tester.cpp
@@ -1,0 +1,20 @@
+// Simple node for publishing and listening to blink messages
+#include <lcm/lcm-cpp.hpp>
+#include "biped_lcm/commData2Teensy.hpp"
+#include <iostream>
+
+using namespace biped_lcm;
+
+int main(){
+	lcm::LCM lcm;
+	if(!lcm.good())
+		return 1;
+
+	while(lcm.good()){
+		commData2Teensy msg;
+		std::cin >> msg.command;
+		std::cout << "Publishing command " << msg.command << std::endl;
+		lcm.publish("teensy_ul_cmd_mode", &msg);
+	}
+	return 0;
+}

--- a/cmd_tester/cmd_tester.cpp
+++ b/cmd_tester/cmd_tester.cpp
@@ -14,7 +14,7 @@ int main(){
 		commData2Teensy msg;
 		std::cin >> msg.command;
 		std::cout << "Publishing command " << msg.command << std::endl;
-		lcm.publish("teensy_ul_cmd_mode", &msg);
+		lcm.publish("UL_cmd_mode", &msg);
 	}
 	return 0;
 }

--- a/common/serial_channels.hpp
+++ b/common/serial_channels.hpp
@@ -3,6 +3,6 @@
 #define SERIAL_CHANNELS_HPP_
 
 // IDs for serial channels
-enum ChannelID : uint8_t {LOG_MSG, STATE, CMD_MODE, CMD_POS};
+enum class ChannelID : uint8_t {LOG_MSG, STATE, CMD_MODE, CMD_POS};
 
 #endif

--- a/common/serial_channels.hpp
+++ b/common/serial_channels.hpp
@@ -1,0 +1,8 @@
+// Common include for info shared by teensy and other processes
+#ifndef SERIAL_CHANNELS_HPP_
+#define SERIAL_CHANNELS_HPP_
+
+// IDs for serial channels
+enum ChannelID : uint8_t {LOG_MSG, STATE, CMD_MODE, CMD_POS};
+
+#endif

--- a/log_listener/Makefile
+++ b/log_listener/Makefile
@@ -1,0 +1,9 @@
+# NEEDED VARS: BDIR_ABS, LCM_BDIR_ABS, TARGET
+
+LIBS= -lserial 
+
+#optional vars for include, src:
+#IDIR=  
+#SDIR=
+
+include ../Common.mk

--- a/log_listener/log_listener.cpp
+++ b/log_listener/log_listener.cpp
@@ -1,0 +1,26 @@
+// Simple node for publishing and listening to blink messages
+#include <lcm/lcm-cpp.hpp>
+#include "biped_lcm/log_msg.hpp"
+#include <iostream>
+
+using namespace biped_lcm;
+
+// Print the blink count when message received
+void log_listener(const lcm::ReceiveBuffer* rbuf, 
+					const std::string& channel, 
+					const log_msg* msg, 
+					void* context){
+	std::cout << channel << ":" << msg->log_level << ":" << msg->msg << std::endl;
+}
+
+int main(){
+	lcm::LCM lcm;
+	if(!lcm.good())
+		return 1;
+
+	lcm.subscribeFunction("UL_log_msg", &log_listener, (void*)nullptr);
+
+	while(0 == lcm.handle());
+
+	return 0;
+}

--- a/onboard/log_util.hpp
+++ b/onboard/log_util.hpp
@@ -1,0 +1,45 @@
+#ifndef LOG_UTIL_HPP_
+#define LOG_UTIL_HPP_
+
+#include <iostream>
+#include <sstream>
+
+#include "slave_bridge.hpp"
+#include "biped_lcm/log_msg.hpp"
+#include "common/serial_channels.hpp"
+
+using namespace biped_lcm;
+
+class Logger : public std::ostream{
+private:
+	class LogBuf : public std::stringbuf{
+	private:
+		const LCMSerialSlave& lcm;
+		const uint8_t log_level;	
+	public:
+		LogBuf(const LCMSerialSlave& lcm, uint8_t log_level):
+			lcm(lcm), log_level(log_level){}
+		~LogBuf(){
+			pubsync();
+		}
+
+		// sync() is called on std::flush (or std::endl)
+		// publish the current string on lcm
+		int sync(){
+			log_msg msg;
+			msg.msg = str();
+			str(""); // Clear current string
+			msg.log_level = log_level;
+			return lcm.publish(ChannelID::LOG_MSG, &msg);
+		}
+	};
+public:
+	Logger(const LCMSerialSlave& lcm, uint8_t log_level):
+		std::ostream(new LogBuf(lcm, log_level)){}
+	~Logger(){ 
+		delete rdbuf();
+	}
+};
+
+
+#endif

--- a/onboard/log_util.hpp
+++ b/onboard/log_util.hpp
@@ -30,7 +30,8 @@ private:
 			msg.msg = str();
 			str(""); // Clear current string
 			msg.log_level = log_level;
-			return lcm.publish(ChannelID::LOG_MSG, &msg);
+			lcm.publish(ChannelID::LOG_MSG, &msg);
+			return 0;
 		}
 	};
 public:

--- a/onboard/main.cpp
+++ b/onboard/main.cpp
@@ -222,7 +222,7 @@ void setup() {
   }
   Timer3.initialize(1000); //1 ms
   Timer3.attachInterrupt(timerCallback);
-  lcm.subscribe(ChannelID::CMD_MODE, &callback); // 0 is incoming, 1 is out
+  lcm.subscribe(ChannelID::CMD_MODE, &callback);
 }
 
 // Main loop

--- a/onboard/main.cpp
+++ b/onboard/main.cpp
@@ -16,7 +16,7 @@ const int numOfJoints = 3;
 LCMSerialSlave lcm; //initialize LCM object
 Logger loginfo(lcm, log_msg::INFO);
 Logger logwarn(lcm, log_msg::WARN);
-Logger logerr(lcm, log_msg::ERROR);
+Logger logerror(lcm, log_msg::ERROR);
 
 std::vector<JointROM> jointMem; // initialize array of 3 ROM memory structs
 std::vector<Joint> joints; //vector of joints
@@ -65,9 +65,7 @@ void ID_Request(){
 // //==============================State Machine functions===================================
 void Calibration_State(){
   if (joints[currLocalJoint].CalibrationCheck() == false) {
-    error_channel error_msg;
-    // error_msg.name = "potentiometer hardware out of range";
-    lcm.publish(ChannelID::LOG_MSG, &error_msg);
+    logerror << "potentiometer hardware out of range" << std::flush;
     state = STATES::WAIT;
   }
 }
@@ -76,9 +74,7 @@ void Static_Control_State(){
   bool OutOfRange = joints[currLocalJoint].checkOOR();
   if (OutOfRange) {
     stopMotors();
-    error_channel error_msg;
-    // error_msg.name = "out of range";
-    lcm.publish(LOG_MSG, &error_msg);
+    logerror << "out of range" << std::flush;
     state = STATES::WAIT;
   }
   else{
@@ -90,9 +86,7 @@ void Static_Control_All_State(){
   bool OutOfRange = joints[0].checkOOR()||joints[1].checkOOR()||joints[2].checkOOR();
   if (OutOfRange) {
     stopMotors();
-    error_channel error_msg;
-    // error_msg.name = "out of range";
-    lcm.publish(ChannelID::LOG_MSG, &error_msg);
+    logerror << "out of range" << std::flush;
     state = STATES::WAIT;
   }
   else{
@@ -112,9 +106,7 @@ void stateAssignment(int command){
         ID_Request();
       }
       else{
-        error_channel msg_Out;
-        // msg_Out.name = "inappropriate command";
-        lcm.publish(ChannelID::LOG_MSG, &msg_Out);
+        logerror << "inappropriate command" << std::flush;
       }
       break;
 
@@ -127,9 +119,7 @@ void stateAssignment(int command){
         state = STATES::CALIBRATION;
       }
       else{
-        error_channel msg_Out;
-        // msg_Out.name = "inappropriate command";
-        lcm.publish(ChannelID::LOG_MSG, &msg_Out);
+        logerror << "inappropriate command" << std::flush;
       }
       break;
 
@@ -143,9 +133,7 @@ void stateAssignment(int command){
         state = STATES::WAIT;
       }
       else{
-        error_channel msg_Out;
-        // msg_Out.name = "inappropriate command";
-        lcm.publish(ChannelID::LOG_MSG, &msg_Out);
+        logerror << "inappropriate command" << std::flush;
       }
       break;
 
@@ -157,9 +145,7 @@ void stateAssignment(int command){
         lcm.publish(ChannelID::STATE, &msg_Out);
       }
       else{
-        error_channel msg_Out;
-        // msg_Out.name = "inappropriate command";
-        lcm.publish(ChannelID::LOG_MSG, &msg_Out);
+        logerror << "inappropriate command" << std::flush;
       }
       break;
 
@@ -173,9 +159,7 @@ void stateAssignment(int command){
         state = commData2Teensy::RUN_STATIC_CONTROL;
       }
       else{
-        error_channel msg_Out;
-        // msg_Out.name = "inappropriate command";
-        lcm.publish(ChannelID::LOG_MSG, &msg_Out);
+        logerror << "inappropriate command" << std::flush;
       }
       break;
 
@@ -188,9 +172,7 @@ void stateAssignment(int command){
         state = commData2Teensy::RUN_STATIC_ALL;
       }
       else{
-        error_channel msg_Out;
-        // msg_Out.name = "inappropriate command";
-        lcm.publish(ChannelID::LOG_MSG, &msg_Out);
+        logerror << "inappropriate command" << std::flush;
       }
       break;
 
@@ -209,7 +191,7 @@ void stateAssignment(int command){
 }
 
 //============================CALLBACK====================================
-void callback(CHANNEL_ID id, commData2Teensy* msg_IN){
+void callback(ChannelID id, commData2Teensy* msg_IN){
   int command = msg_IN->command;
   int currJoint = msg_IN->joint;
   currLocalJoint = convertToLocalJointNumber(currJoint);

--- a/onboard/main.cpp
+++ b/onboard/main.cpp
@@ -3,16 +3,21 @@
 #include "slave_bridge.hpp" //LCM slave file
 #include "biped_lcm/commData2Teensy.hpp" // header file for data from dispatcher to teensy
 #include "biped_lcm/commDataFromTeensy.hpp" // header file for data from teensy to dispatcher
-#include "biped_lcm/error_channel.hpp" //header file for error messages
 #include "Joint.h" // struct that stores joint data
 #include "JointTable.h"
 #include "common/serial_channels.hpp"
+#include "biped_lcm/log_msg.hpp"
+#include "log_util.hpp"
 
 using namespace biped_lcm; // for messages
 
 const int numOfJoints = 3;
 
 LCMSerialSlave lcm; //initialize LCM object
+Logger loginfo(lcm, log_msg::INFO);
+Logger logwarn(lcm, log_msg::WARN);
+Logger logerr(lcm, log_msg::ERROR);
+
 std::vector<JointROM> jointMem; // initialize array of 3 ROM memory structs
 std::vector<Joint> joints; //vector of joints
 

--- a/onboard/slave_bridge.hpp
+++ b/onboard/slave_bridge.hpp
@@ -53,7 +53,7 @@ public:
 	 * @return 0 on success, -1 on failure
 	 */
 	template<typename MessageType>
-	int publish(ChannelID channel_id, const MessageType* msg);
+	int publish(ChannelID channel_id, const MessageType* msg) const;
 
 	/** Subscribe to a serial LCM Message that will trigger a callback function
 	 * @param channel_id id of channel to subscribe to

--- a/onboard/slave_bridge.hpp
+++ b/onboard/slave_bridge.hpp
@@ -1,10 +1,9 @@
 #include "fix_std.hpp"
+#include "common/serial_channels.hpp"
 #include <map>
 
 #ifndef SLAVE_BRIDGE_HPP_
 #define SLAVE_BRIDGE_HPP_
-
-using CHANNEL_ID = uint8_t;
 
 enum ReadState {
 	FIND_HEADER,
@@ -18,13 +17,13 @@ enum ReadState {
 class LCMSerialSlave {
 private:
 	struct ChannelDef {
-		CHANNEL_ID id;
+		ChannelID id;
 		void (ChannelDef::*decoder)(byte*,uint32_t);
-		void (*handler)(CHANNEL_ID, void*);
+		void (*handler)(ChannelID, void*);
 
 		template <typename MessageType>
 		void decoder_fun(byte* buf, uint32_t len){
-			auto typed_handler = reinterpret_cast<void (*)(CHANNEL_ID, MessageType*)>(handler);
+			auto typed_handler = reinterpret_cast<void (*)(ChannelID, MessageType*)>(handler);
 
 			// Decode message and call handler
 			MessageType msg;
@@ -35,14 +34,14 @@ private:
 	};
 
 	// Map of channel IDs to message-handler functions
-	std::map<CHANNEL_ID, ChannelDef> input_channels;
+	std::map<ChannelID, ChannelDef> input_channels;
 
 	ReadState read_state = FIND_HEADER;
-	uint8_t last_channel_id;
+	ChannelID last_channel_id;
 	uint32_t data_len;
 	byte datalen_buf[sizeof(data_len)];
 	uint32_t data_buf_p = 0;
-	byte* data_buf;
+	byte* data_buf; //TODO smart pointers
 
 public:
 	LCMSerialSlave();
@@ -54,7 +53,7 @@ public:
 	 * @return 0 on success, -1 on failure
 	 */
 	template<typename MessageType>
-	int publish(CHANNEL_ID channel_id, const MessageType* msg);
+	int publish(ChannelID channel_id, const MessageType* msg);
 
 	/** Subscribe to a serial LCM Message that will trigger a callback function
 	 * @param channel_id id of channel to subscribe to
@@ -63,7 +62,7 @@ public:
 	 * @return 0 on success, -1 on failure
 	 */
 	template<typename MessageType>
-	int subscribe(CHANNEL_ID channel_id, void (*handler)(CHANNEL_ID, MessageType*));
+	int subscribe(ChannelID channel_id, void (*handler)(ChannelID, MessageType*));
 
 	/** Handle all available serial messages. Does not block if nothing is available.
 	 * @param max_bytes maximum number of bytes to read before returning.

--- a/onboard/slave_bridge_impl.hpp
+++ b/onboard/slave_bridge_impl.hpp
@@ -8,7 +8,7 @@ LCMSerialSlave::LCMSerialSlave(){
 }
 
 template<typename MessageType>
-int LCMSerialSlave::publish(ChannelID channel_id, const MessageType* msg){
+int LCMSerialSlave::publish(ChannelID channel_id, const MessageType* msg) const{
 	uint32_t size = msg->getEncodedSize();
 
 	// Allocate enough room for the header and body

--- a/serial_bridge/bridge.hpp
+++ b/serial_bridge/bridge.hpp
@@ -3,6 +3,7 @@
 
 #include <SerialStream.h>
 #include <lcm/lcm-cpp.hpp>
+#include "common/serial_channels.hpp"
 
 #ifndef MASTER_BRIDGE_HPP_
 #define MASTER_BRIDGE_HPP_
@@ -33,11 +34,11 @@ private:
 	lcm::LCM lcm;
 	LibSerial::SerialStream serial;
 
-	std::map<const std::string, uint8_t> input_channel_ids;
-	std::map<uint8_t, ChannelDef> output_channels;
+	std::map<const std::string, ChannelID> input_channel_ids;
+	std::map<ChannelID, ChannelDef> output_channels;
 
 	ReadState read_state = FIND_HEADER;
-	uint8_t last_channel_id;
+	ChannelID last_channel_id;
 	uint32_t data_len;
 	byte datalen_buf[sizeof(data_len)];
 	uint32_t data_buf_p = 0;
@@ -60,7 +61,7 @@ public:
 	 * @param channel_id the byte used as a channel identifier
 	 * @param channel_name name of lcm channel
 	 */
-	void add_subscriber(uint8_t channel_id, const std::string& channel_name);
+	void add_subscriber(ChannelID channel_id, const std::string& channel_name);
 
 	/** Add a channel that the bridge reads from serial and publishes
 	 * out across LCM
@@ -68,7 +69,7 @@ public:
 	 * @param channel_name name of lcm channel
 	 */
 	template <typename MessageType>
-	void add_publisher(uint8_t channel_id, const std::string& channel_name);
+	void add_publisher(ChannelID channel_id, const std::string& channel_name);
 
 	/** Read from serial and publish any complete LCM messages
 	 * @param max_bytes maximum number of bytes to process. -1 means "process all"

--- a/serial_bridge/bridge_impl.hpp
+++ b/serial_bridge/bridge_impl.hpp
@@ -9,7 +9,7 @@
 #error "Don't include this file directly"
 #endif
 
-// #define DEBUG //TODO: proper logging
+#define DEBUG //TODO: proper logging
 
 LCMSerialBridge::LCMSerialBridge(const std::string& port, LibSerial::SerialStreamBuf::BaudRateEnum baud)
 {
@@ -22,7 +22,7 @@ LCMSerialBridge::LCMSerialBridge(const std::string& port, LibSerial::SerialStrea
 	}
 }
 
-void LCMSerialBridge::add_subscriber(uint8_t channel_id, const std::string& channel_name) {
+void LCMSerialBridge::add_subscriber(ChannelID channel_id, const std::string& channel_name) {
 	std::cout << "Subscribing to " << channel_name << std::endl;
 
 	input_channel_ids[channel_name] = channel_id;
@@ -30,7 +30,9 @@ void LCMSerialBridge::add_subscriber(uint8_t channel_id, const std::string& chan
 }
 
 template <typename MessageType>
-void LCMSerialBridge::add_publisher(uint8_t channel_id, const std::string& channel_name) {
+void LCMSerialBridge::add_publisher(ChannelID channel_id, const std::string& channel_name) {
+	std::cout << "Publishing to " << channel_name << std::endl;
+
 	ChannelDef channel;
 	channel.name = channel_name;
 	channel.lcm = &lcm;
@@ -51,7 +53,7 @@ void LCMSerialBridge::pass_to_serial(const lcm::ReceiveBuffer* rbuf, const std::
 	#endif
 
 	// Write the ID
-	serial << input_channel_ids[channel_name]; 
+	serial << static_cast<uint8_t>(input_channel_ids[channel_name]); 
 	// Write the data length
 	serial.write((byte*)(&rbuf->data_size), sizeof(rbuf->data_size)); //TODO cast properly TODO use streams instead
 	//Write the data itself
@@ -70,8 +72,9 @@ void LCMSerialBridge::process_serial(int max_bytes){
 			// Locate the first byte of the next message
 			case FIND_HEADER: {
 				// Is this a valid channel ID? Invalids are skipped
-				if(output_channels.count(next_byte)){
-					last_channel_id = next_byte;
+				ChannelID chan_id = static_cast<ChannelID>(next_byte);
+				if(output_channels.count(chan_id)){
+					last_channel_id = chan_id;
 					read_state = READ_LEN;
 				}
 				break;

--- a/serial_bridge/main.cpp
+++ b/serial_bridge/main.cpp
@@ -7,12 +7,18 @@
 // Open a bridge for passing the blink messages around
 // TODO: global storage of channel IDs
 
+typedef ChannelID CID;
+
 int main(){
-	LCMSerialBridge bridge("/dev/ttyACM0");
-	std::cout << "Opened port" << std::endl;
-	bridge.add_subscriber(0, "TO_TEENSY");
-	bridge.add_publisher<biped_lcm::error_channel>(2, "ERROR");
-	bridge.add_publisher<biped_lcm::commDataFromTeensy>(1, "FROM_TEENSY");
+	std::string port = "/dev/ttyACM0";
+	std::string prefix = "teensy_ul_";
+	LCMSerialBridge bridge(port);
+	std::cout << "Opened port " << port << std::endl;
+
+	bridge.add_subscriber(CID::CMD_MODE, prefix+"cmd_mode");
+
+	bridge.add_publisher<biped_lcm::log_msg>(CID::LOG_MSG, prefix+"log_msg");
+	bridge.add_publisher<biped_lcm::commDataFromTeensy>(CID::STATE, prefix+"state");
 
 	while(1){
 		bridge.handle(1);

--- a/serial_bridge/main.cpp
+++ b/serial_bridge/main.cpp
@@ -2,7 +2,7 @@
 #include "bridge.hpp"
 #include "biped_lcm/commData2Teensy.hpp"
 #include "biped_lcm/commDataFromTeensy.hpp"
-#include "biped_lcm/error_channel.hpp"
+#include "biped_lcm/log_msg.hpp"
 
 // Open a bridge for passing the blink messages around
 // TODO: global storage of channel IDs

--- a/serial_bridge/main.cpp
+++ b/serial_bridge/main.cpp
@@ -11,7 +11,7 @@ typedef ChannelID CID;
 
 int main(){
 	std::string port = "/dev/ttyACM0";
-	std::string prefix = "teensy_ul_";
+	std::string prefix = "UL_";
 	LCMSerialBridge bridge(port);
 	std::cout << "Opened port " << port << std::endl;
 


### PR DESCRIPTION
Channel IDs are now typed and defined in a common file.
Debug and error messages can now be sent using streams from the onboard code: `loginfo << "message" << my_var << std::flush`

cmd_tester is a basic utility to send commands. Enter the mode number and hit <enter> to send.
log_listener is a utility to echo the logger messages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/samkhal/biped/16)
<!-- Reviewable:end -->
