### PR TITLE
dispatcher working

### DIFF
--- a/biped_lcm/LiveControlAll.lcm
+++ b/biped_lcm/LiveControlAll.lcm
@@ -1,0 +1,9 @@
+package biped_lcm;
+
+struct LiveControlAll
+{
+	int8_t num_joints;
+	int8_t joint_ids[num_joints];
+	float torque[num_joints];
+	float angle[num_joints];
+}

--- a/cmd_tester/cmd_tester.cpp
+++ b/cmd_tester/cmd_tester.cpp
@@ -4,9 +4,12 @@
 #include "biped_lcm/commDataFromTeensy.hpp" // header file for data from teensy to dispatcher
 #include "biped_lcm/LiveControl2Teensy.hpp" //header file for live messages
 #include "biped_lcm/LiveControlFromTeensy.hpp" //header file for live messages
+#include "biped_lcm/LiveControlAll.hpp" 
 #include "common/serial_channels.hpp"
 #include "biped_lcm/log_msg.hpp"
 #include <iostream>
+#include <unistd.h>
+
 
 using namespace biped_lcm;
 
@@ -43,9 +46,9 @@ int main(){
 	if(!lcm.good())
 		return 1;
 
-	lcm.subscribeFunction("cmd_response", &cmdResponseListener, (void*)nullptr);
-	lcm.subscribeFunction("log_msg", &logMsgListener, (void*)nullptr);
-	lcm.subscribeFunction("live_out", &liveControlListener, (void*)nullptr);
+	lcm.subscribeFunction("UR_cmd_response", &cmdResponseListener, (void*)nullptr);
+	lcm.subscribeFunction("UR_log_msg", &logMsgListener, (void*)nullptr);
+	lcm.subscribeFunction("UR_live_out", &liveControlListener, (void*)nullptr);
 
 	commData2Teensy msg;
 	std::cin >> msg.command;
@@ -53,14 +56,23 @@ int main(){
 		msg.joint = 1;
 	}
 	std::cout << "Publishing command " << msg.command << std::endl;
-	lcm.publish("cmd_in", &msg);
+	lcm.publish("UR_cmd_in", &msg);
 	while(lcm.good()){
-		lcm.handle();
-		LiveControl2Teensy msgOut;
-	  msgOut.joint = 1;
-		msgOut.torque = 0.303f; //random values
-		msgOut.angle = 0.52f;
-		lcm.publish("live_in", &msgOut);
+		lcm.handleTimeout(0);
+		LiveControlAll msgOut;
+		msgOut.num_joints = 2;
+		msgOut.joint_ids = {1,2};
+		msgOut.torque = {0.303f,0.403f};
+		msgOut.angle = {0.52f, 0.54f};
+		lcm.publish("live_in",&msgOut);
+
+		// lcm.publish("live_in", &msgOut);
+		// LiveControl2Teensy msgOut;
+	 //  	msgOut.joint = 1;
+		// msgOut.torque = 0.303f; //random values
+		// msgOut.angle = 0.52f;
+		// lcm.publish("UR_live_in",&msgOut);
+		usleep(10000);
 	}
 	return 0;
 }

--- a/safety_check/main.cpp
+++ b/safety_check/main.cpp
@@ -38,8 +38,8 @@ int main(){
 	if(!lcm.good())
 		return 1;
 
-  lcm.subscribeFunction("cmd_in", &cmdListener, (void*)nullptr);
-	lcm.subscribeFunction("heartbeat", &heartBeatListener, (void*)nullptr);
+  lcm.subscribeFunction("UR_cmd_in", &cmdListener, (void*)nullptr);
+	lcm.subscribeFunction("UR_heartbeat", &heartBeatListener, (void*)nullptr);
 
 	while(lcm.good()){
 		lcm.handleTimeout(0);
@@ -48,7 +48,7 @@ int main(){
       if (heartBeatFlag){
         heartBeatResponse msgOut;
         msgOut.beat = true;
-        lcm.publish("heartbeatresponse", &msgOut);
+        lcm.publish("UR_heartbeatresponse", &msgOut);
         heartBeatFlag = false;
         counter = 0;
       }

--- a/serial_bridge/main.cpp
+++ b/serial_bridge/main.cpp
@@ -1,9 +1,12 @@
 #include <iostream>
+#include <string>
+#include <map>
 #include "bridge.hpp"
 #include "biped_lcm/commData2Teensy.hpp"
 #include "biped_lcm/commDataFromTeensy.hpp"
 #include "biped_lcm/log_msg.hpp"
 #include "biped_lcm/LiveControl2Teensy.hpp" //header file for live messages
+#include "biped_lcm/LiveControlAll.hpp" 
 #include "biped_lcm/LiveControlFromTeensy.hpp" //header file for live messages
 #include "biped_lcm/heartBeat.hpp"
 #include "biped_lcm/heartBeatResponse.hpp"
@@ -11,27 +14,86 @@
 // Open a bridge for passing the blink messages around
 // TODO: global storage of channel IDs
 
+using namespace biped_lcm;
+
 typedef ChannelID CID;
+std::vector<std::string> prefixes = {"UR","UL","LR","LL"};
+std::map<int8_t,int8_t> joint_map = {{1,0}, //Maps joint ids to teensies (index into prefix array)
+									 {2,0},
+									 {3,0},
+									 {4,1},
+									 {5,1},
+									 {6,1},
+									 {7,2},
+									 {8,2},
+									 {9,2},
+									 {10,3},
+									 {11,3},
+									 {12,3}};
 
-int main(){
 
-	std::string port = "/dev/ttyACM0";
-	std::string prefix = "";
-	LCMSerialBridge bridge(port);
-	std::cout << "Opened port " << port << std::endl;
+std::string live_in_channel = "live_in";
+lcm::LCM dispatcher;
 
-	bridge.add_subscriber(CID::CMD_IN, prefix+"cmd_in");
-	bridge.add_subscriber(CID::LIVE_IN, prefix+"live_in");
-	bridge.add_subscriber(CID::HEARTBEATRESPONSE, prefix+"heartbeatresponse");
+void dispatchControl(const lcm::ReceiveBuffer* rbuf,
+					const std::string& channel,
+					const LiveControlAll* msg,
+					void* context){
 
-	bridge.add_publisher<biped_lcm::heartBeat>(CID::HEARTBEAT, prefix+"heartbeat");
-	bridge.add_publisher<biped_lcm::log_msg>(CID::LOG_MSG, prefix+"log_msg");
-	bridge.add_publisher<biped_lcm::commDataFromTeensy>(CID::CMD_RESPONSE, prefix+"cmd_response");
-	bridge.add_publisher<biped_lcm::LiveControlFromTeensy>(CID::LIVE_OUT, prefix+"live_out");
+	std::cout<< "p";
+	for(int i=0; i<msg->num_joints; i++){
+		LiveControl2Teensy new_msg;
+		new_msg.joint = msg->joint_ids[i];
+		new_msg.torque = msg->torque[i];
+		new_msg.angle = msg->angle[i];
+
+		std::string dest = prefixes[joint_map[new_msg.joint]]+"_"+live_in_channel;
+		dispatcher.publish(dest, &new_msg);
+	}
+}
+
+int main(int argc, char *argv[]){
+	// arguments passed in as paths to upper-right, upper-left, lower-right, lower-left serial ports
+	if(argc<2 or argc>5){
+		std::cout<<"List device paths in order: UR, UL, LR, LL"<<std::endl;
+		std::cout<<"Usage: "<< argv[0] << " /dev/ttyACMx /dev/ttyACMx ..." << std::endl;
+		return 1;
+	}
+
+	std::vector<LCMSerialBridge*> bridges;
+
+	for(int i=0; i<argc-1; i++){
+		std::string prefix = prefixes[i];
+		std::string port = argv[i+1];
+		LCMSerialBridge* bridge = new LCMSerialBridge(port);
+		std::cout << "Opened port " << port << " for teensy " << prefix << std::endl;
+
+		bridge->add_subscriber(CID::CMD_IN, prefix+"_cmd_in");
+		bridge->add_subscriber(CID::LIVE_IN, prefix+"_"+live_in_channel);
+		bridge->add_subscriber(CID::HEARTBEATRESPONSE, prefix+"_heartbeatresponse");
+
+		bridge->add_publisher<heartBeat>(CID::HEARTBEAT, prefix+"_heartbeat");
+		bridge->add_publisher<log_msg>(CID::LOG_MSG, prefix+"_log_msg");
+		bridge->add_publisher<commDataFromTeensy>(CID::CMD_RESPONSE, prefix+"_cmd_response");
+		bridge->add_publisher<LiveControlFromTeensy>(CID::LIVE_OUT, prefix+"_live_out");
+
+		bridges.push_back(bridge);
+	}
+
+	// Set up dispatcher
+	if(!dispatcher.good()){
+		std::cout << "LCM error" << std::endl;
+		return 1;
+	}
+
+	dispatcher.subscribeFunction(live_in_channel, &dispatchControl, (void*)nullptr);
 
 	while(1){
-		bridge.handle(1);
-		bridge.process_serial();
+		for(int i=0; i<bridges.size(); i++){
+			bridges[i]->handle(0);
+			bridges[i]->process_serial();
+		}
+		dispatcher.handleTimeout(0);
 		usleep(1000); //1 ms
 	}
 	return 0;


### PR DESCRIPTION
Simple approach to dispatcher.
Doesn't run as a separate node, runs within serial bridge's main. 

All channels now have a naming convention: those with a prefix, like UR_live_in, represent only messages destined for the UR (upper right) teensy. "live_in" with no prefix contains several arrays of equal length, and can command any number of joints at once. The dispatcher translates "live_in" into "UR_live_in", etc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/samkhal/biped/30)
<!-- Reviewable:end -->
